### PR TITLE
fix: correct lang parameter condition in redirectToLogin

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -274,7 +274,7 @@ export class FiefAuth {
       codeChallenge,
       codeChallengeMethod: 'S256',
       ...parameters?.state ? { state: parameters.state } : {},
-      ...parameters?.state ? { lang: parameters.lang } : {},
+      ...parameters?.lang ? { lang: parameters.lang } : {},
       ...parameters?.extrasParams ? { extrasParams: parameters.extrasParams } : {},
     });
     window.location.href = authorizeURL;


### PR DESCRIPTION
## Issue Description

In the `redirectToLogin` method, there's an error in the logic for passing the `lang` parameter. The current code binds the `lang` parameter to the existence of the `state` parameter:

```typescript
...parameters?.state ? { lang: parameters.lang } : {},
```

This causes the `lang` parameter to be passed only when the `state` parameter exists, making it ineffective when passing only the `lang` parameter.

## Fix

Modified the condition to make the `lang` parameter's transmission depend only on the existence of the `lang` parameter itself:

```typescript
...parameters?.lang ? { lang: parameters.lang } : {},
```

With this change, the `lang` parameter will be correctly passed to the authorization URL regardless of whether the `state` parameter is provided.